### PR TITLE
Refactor pattern matching in Problem 10 Solution 3

### DIFF
--- a/P01to10/Solutions.fs
+++ b/P01to10/Solutions.fs
@@ -289,12 +289,8 @@ let encode' xs = xs |> pack |> List.map(fun xs -> List.length xs, List.head xs)
 (*[omit:(Solutions 3)]*)
 let encode'' xs = 
     let collect x = function
-        | [] -> [(1, x)]
-        | (n,y)::xs as acc-> 
-            if x = y then
-                (n+1, y)::xs
-            else
-                (1,x)::acc
+        | (n,y)::xs when x = y -> (n+1,y)::xs
+        | acc -> (1,x)::acc
     List.foldBack collect xs []
 (*[/omit]*)
 // [/snippet]


### PR DESCRIPTION
The pattern matching can be simplified. The proposed change is similar to the solution of problem 9.

If x is the same as the previous element (y) increment the counter by 1. Otherwise the element is not the same and it is added as a new item to the accumulator. The second rule covers the case of an empty accumulator too – the new element gets added to an empty list.